### PR TITLE
Add omitted zeroes to solutions

### DIFF
--- a/MIP-glpk/src/Numeric/Optimization/MIP/Solver/GLPK.hs
+++ b/MIP-glpk/src/Numeric/Optimization/MIP/Solver/GLPK.hs
@@ -46,7 +46,9 @@ glpk :: GLPK
 glpk = GLPK
 
 instance IsSolver GLPK IO where
-  solve _solver opt prob =
+  solve = solve'
+  
+  solve' _solver opt prob =
     (if rtsSupportsBoundThreads then runInBoundThread else id) $
     bracket Raw.glp_init_env (\ret -> when (ret == 0) $ Raw.glp_free_env >> return ()) $ \_ -> do
     bracket Raw.glp_create_prob Raw.glp_delete_prob $ \prob' -> do

--- a/MIP/src/Numeric/Optimization/MIP/Solver.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver.hs
@@ -20,7 +20,7 @@ module Numeric.Optimization.MIP.Solver
   , module Numeric.Optimization.MIP.Solver.SCIP
   ) where
 
-import Numeric.Optimization.MIP.Solver.Base
+import Numeric.Optimization.MIP.Solver.Base hiding (solve')
 import Numeric.Optimization.MIP.Solver.CBC
 import Numeric.Optimization.MIP.Solver.CPLEX
 import Numeric.Optimization.MIP.Solver.Glpsol

--- a/MIP/src/Numeric/Optimization/MIP/Solver/Base.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/Base.hs
@@ -31,6 +31,8 @@ data SolveOptions
     -- ^ invoked when a solver output a line
   , solveErrorLogger :: String -> IO ()
     -- ^ invoked when a solver output a line to stderr
+  , solveCondensedSolution :: Bool
+    -- ^ potentially omit variables set to zero from the solution
   }
 
 instance Default SolveOptions where
@@ -39,13 +41,14 @@ instance Default SolveOptions where
     { solveTimeLimit = Nothing
     , solveLogger = const $ return ()
     , solveErrorLogger = const $ return ()
+    , solveCondensedSolution = False
     }
 
 
 class Monad m => IsSolver s m | s -> m where
   solve' :: s -> SolveOptions -> MIP.Problem Scientific -> m (MIP.Solution Scientific)
   solve  :: s -> SolveOptions -> MIP.Problem Scientific -> m (MIP.Solution Scientific)
-  solve s opts problem = addZeroes problem <$> solve' s opts problem
+  solve s opts problem = (if solveCondensedSolution opts then addZeroes problem else id) <$> solve' s opts problem
   {-# MINIMAL solve' #-}
 
 -- Several solvers (at least CBC) do not include any variables set to 0 in their solution.

--- a/MIP/src/Numeric/Optimization/MIP/Solver/Base.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/Base.hs
@@ -21,6 +21,7 @@ module Numeric.Optimization.MIP.Solver.Base
 import Data.Default.Class
 import Data.Scientific (Scientific)
 import Numeric.Optimization.MIP.Base as MIP
+import qualified Data.Map as Map
 
 data SolveOptions
   = SolveOptions
@@ -40,5 +41,17 @@ instance Default SolveOptions where
     , solveErrorLogger = const $ return ()
     }
 
+
 class Monad m => IsSolver s m | s -> m where
-  solve :: s -> SolveOptions -> MIP.Problem Scientific -> m (MIP.Solution Scientific)
+  solve' :: s -> SolveOptions -> MIP.Problem Scientific -> m (MIP.Solution Scientific)
+  solve  :: s -> SolveOptions -> MIP.Problem Scientific -> m (MIP.Solution Scientific)
+  solve s opts problem = addZeroes problem <$> solve' s opts problem
+  {-# MINIMAL solve' #-}
+
+-- Several solvers (at least CBC) do not include any variables set to 0 in their solution.
+-- TODO: for solvers that do return all variables, add `solve = solve'`
+-- for a minor performance improvement.
+addZeroes :: MIP.Problem Scientific -> MIP.Solution Scientific -> MIP.Solution Scientific
+addZeroes problem (Solution stat obj solmap) = 
+  -- Map.union is left-biased: only values not present in the solution are added.
+  Solution stat obj $ Map.union solmap (Map.fromSet (const 0) (vars problem))

--- a/MIP/src/Numeric/Optimization/MIP/Solver/Base.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/Base.hs
@@ -48,7 +48,7 @@ instance Default SolveOptions where
 class Monad m => IsSolver s m | s -> m where
   solve' :: s -> SolveOptions -> MIP.Problem Scientific -> m (MIP.Solution Scientific)
   solve  :: s -> SolveOptions -> MIP.Problem Scientific -> m (MIP.Solution Scientific)
-  solve s opts problem = (if solveCondensedSolution opts then addZeroes problem else id) <$> solve' s opts problem
+  solve s opts problem = (if solveCondensedSolution opts then id else addZeroes problem) <$> solve' s opts problem
   {-# MINIMAL solve' #-}
 
 -- Several solvers (at least CBC) do not include any variables set to 0 in their solution.

--- a/MIP/src/Numeric/Optimization/MIP/Solver/CBC.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/CBC.hs
@@ -41,7 +41,7 @@ cbc :: CBC
 cbc = CBC "cbc" []
 
 instance IsSolver CBC IO where
-  solve solver opt prob = do
+  solve' solver opt prob = do
     case LPFile.render def prob{ MIP.objectiveFunction = obj' } of
       Left err -> ioError $ userError err
       Right lp -> do

--- a/MIP/src/Numeric/Optimization/MIP/Solver/CPLEX.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/CPLEX.hs
@@ -44,7 +44,7 @@ cplex :: CPLEX
 cplex = CPLEX "cplex" [] []
 
 instance IsSolver CPLEX IO where
-  solve solver opt prob = do
+  solve' solver opt prob = do
     case LPFile.render def prob of
       Left err -> ioError $ userError err
       Right lp -> do

--- a/MIP/src/Numeric/Optimization/MIP/Solver/Glpsol.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/Glpsol.hs
@@ -43,7 +43,7 @@ glpsol :: Glpsol
 glpsol = Glpsol "glpsol" []
 
 instance IsSolver Glpsol IO where
-  solve solver opt prob = do
+  solve' solver opt prob = do
     case LPFile.render def prob of
       Left err -> ioError $ userError err
       Right lp -> do

--- a/MIP/src/Numeric/Optimization/MIP/Solver/GurobiCl.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/GurobiCl.hs
@@ -43,7 +43,7 @@ gurobiCl :: GurobiCl
 gurobiCl = GurobiCl "gurobi_cl" []
 
 instance IsSolver GurobiCl IO where
-  solve solver opt prob = do
+  solve' solver opt prob = do
     case LPFile.render def prob of
       Left err -> ioError $ userError err
       Right lp -> do

--- a/MIP/src/Numeric/Optimization/MIP/Solver/LPSolve.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/LPSolve.hs
@@ -45,7 +45,7 @@ lpSolve :: LPSolve
 lpSolve = LPSolve "lp_solve" []
 
 instance IsSolver LPSolve IO where
-  solve solver opt prob = do
+  solve' solver opt prob = do
     case MPSFile.render def prob of
       Left err -> ioError $ userError err
       Right lp -> do

--- a/MIP/src/Numeric/Optimization/MIP/Solver/SCIP.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/SCIP.hs
@@ -41,7 +41,7 @@ scip :: SCIP
 scip = SCIP "scip" [] []
 
 instance IsSolver SCIP IO where
-  solve solver opt prob = do
+  solve' solver opt prob = do
     case LPFile.render def prob of
       Left err -> ioError $ userError err
       Right lp -> do


### PR DESCRIPTION
I noticed that CBC omits some variables set to 0 in its solution file, and I'm not sure how common this is, but the solver I was using previously did not. To make it easier to switch between solvers, I think it is useful to add all omitted variables from the problem to the solution, set to 0.

The current setup is slightly weird, to prevent any breaking changes (i.e. you can still `import MIP.Solver.Base (IsSolver(solve))`).