### PR TITLE
Rename S1 and S2 to SOS1 and SOS2 respectively

### DIFF
--- a/MIP/ChangeLog.md
+++ b/MIP/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Add `Numeric.Optimization.MIP.Solution.MIPLIB` module for reading/writing MIPLIB solution format
 * Add `Domain` type
+* Rename `S1` and `S2` to `SOS1` and `SOS2` respectively. Old names are kept as pattern synonyms.
 
 ## 0.2.0.0 (2025-02-03)
 

--- a/MIP/src/Numeric/Optimization/MIP/Base.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Base.hs
@@ -85,7 +85,7 @@ module Numeric.Optimization.MIP.Base
   , RelOp (..)
 
   -- *** SOS constraints
-  , SOSType (..)
+  , SOSType (SOS1, SOS2, S1, S2)
   , SOSConstraint (..)
 
   -- * Solutions
@@ -459,9 +459,21 @@ data RelOp
 
 -- | types of SOS (special ordered sets) constraints
 data SOSType
-  = S1 -- ^ Type 1 SOS constraint
-  | S2 -- ^ Type 2 SOS constraint
+  = SOS1 -- ^ Type 1 SOS constraint
+  | SOS2 -- ^ Type 2 SOS constraint
   deriving (Eq, Ord, Enum, Show, Read)
+
+-- {-# DEPRECATED S1 "Use SOS1 instead" #-}
+-- | Alias of 'SOS1'
+pattern S1 :: SOSType
+pattern S1 = SOS1
+
+-- {-# DEPRECATED S2 "Use SOS2 instead" #-}
+-- | Alias of 'SOS2'
+pattern S2 :: SOSType
+pattern S2 = SOS2
+
+{-# COMPLETE S1, S2 #-}
 
 -- | SOS (special ordered sets) constraints
 data SOSConstraint c
@@ -633,8 +645,8 @@ instance (Num r, Ord r) => Eval r (SOSConstraint r) where
   type Evaluated r (SOSConstraint r) = Bool
   eval tol sol sos =
     case sosType sos of
-      S1 -> length [() | val <- body, val] <= 1
-      S2 -> f body
+      SOS1 -> length [() | val <- body, val] <= 1
+      SOS2 -> f body
     where
       body = map (not . isInBounds tol (0, 0) . eval tol sol . fst) $ sortBy (comparing snd) $ (sosBody sos)
       f [] = True

--- a/MIP/src/Numeric/Optimization/MIP/LPFile.hs
+++ b/MIP/src/Numeric/Optimization/MIP/LPFile.hs
@@ -377,7 +377,7 @@ sosSection = do
     return $ MIP.SOSConstraint l t xs
   where
     typ = do
-      t <- tok $ (char' 's' >> ((char '1' >> return MIP.S1) <|> (char '2' >> return MIP.S2)))
+      t <- tok $ (char' 's' >> ((char '1' >> return MIP.SOS1) <|> (char '2' >> return MIP.SOS2)))
       tok (string "::")
       return t
 
@@ -533,7 +533,9 @@ render' mip = do
     writeString "SOS\n"
     forM_ (MIP.sosConstraints mip) $ \(MIP.SOSConstraint l typ xs) -> do
       renderLabel l
-      writeString $ fromString $ show typ
+      writeString $ case typ of
+        MIP.SOS1 -> "S1"
+        MIP.SOS2 -> "S2"
       writeString " ::"
       forM_ xs $ \(v, r) -> do
         writeString "  "

--- a/MIP/src/Numeric/Optimization/MIP/MPSFile.hs
+++ b/MIP/src/Numeric/Optimization/MIP/MPSFile.hs
@@ -498,8 +498,8 @@ sosSection = do
   where
     entry = do
       spaces1'
-      typ <-  (try (string "S1") >> return MIP.S1)
-          <|> (string "S2" >> return MIP.S2)
+      typ <-  (try (string "S1") >> return MIP.SOS1)
+          <|> (string "S2" >> return MIP.SOS2)
       spaces1'
       name <- ident
       eol'
@@ -747,8 +747,8 @@ render' opt mip = do
     writeSectionHeader "SOS"
     forM_ (MIP.sosConstraints mip) $ \sos -> do
       let t = case MIP.sosType sos of
-                MIP.S1 -> "S1"
-                MIP.S2 -> "S2"
+                MIP.SOS1 -> "S1"
+                MIP.SOS2 -> "S2"
       writeFields $ t : maybeToList (MIP.sosLabel sos)
       forM_ (MIP.sosBody sos) $ \(var,val) -> do
         writeFields ["", MIP.varName var, showValue val]

--- a/MIP/test/Test/MIP.hs
+++ b/MIP/test/Test/MIP.hs
@@ -84,6 +84,22 @@ prop_status_meet_leq =
 instance Arbitrary MIP.Status where
   arbitrary = arbitraryBoundedEnum
 
+case_sos_pattern_synonym_pattern_match :: Assertion
+case_sos_pattern_synonym_pattern_match = do
+  case MIP.S1 of
+    MIP.SOS1 -> pure ()
+    MIP.SOS2 -> assertFailure "SOS2 should not match S1"
+  case MIP.S2 of
+    MIP.SOS1 -> assertFailure "SOS1 should not match S2"
+    MIP.SOS2 -> pure ()
+
+  case MIP.SOS1 of
+    MIP.S1 -> pure ()
+    MIP.S2 -> assertFailure "S2 should not match SOS1"
+  case MIP.SOS2 of
+    MIP.S1 -> assertFailure "S1 should not match SOS2"
+    MIP.S2 -> pure ()
+
 case_eval_expr :: Assertion
 case_eval_expr = do
   MIP.eval MIP.def sol (MIP.varExpr "x" + 2 * MIP.varExpr "y" :: MIP.Expr Rational) @?= 8
@@ -116,14 +132,14 @@ case_eval_sos_constraint = do
       constr1 =
         MIP.SOSConstraint
         { MIP.sosLabel = Nothing
-        , MIP.sosType = MIP.S1
+        , MIP.sosType = MIP.SOS1
         , MIP.sosBody = [("x1", 1), ("x2", 2), ("x3", 3)]
         }
   MIP.eval MIP.def (Map.fromList [("x1", 0 :: Double), ("x2", 0), ("x3", 0)]) constr1 @?= True
   MIP.eval MIP.def (Map.fromList [("x1", 1 :: Double), ("x2", 0), ("x3", 0)]) constr1 @?= True
   MIP.eval MIP.def (Map.fromList [("x1", 1 :: Double), ("x2", 1), ("x3", 0)]) constr1 @?= False
 
-  let constr2 = constr1{ MIP.sosType = MIP.S2 }
+  let constr2 = constr1{ MIP.sosType = MIP.SOS2 }
   MIP.eval MIP.def (Map.fromList [("x1", 0 :: Double), ("x2", 0), ("x3", 0)]) constr2 @?= True
   MIP.eval MIP.def (Map.fromList [("x1", 1 :: Double), ("x2", 0), ("x3", 0)]) constr2 @?= True
   MIP.eval MIP.def (Map.fromList [("x1", 1 :: Double), ("x2", 1), ("x3", 0)]) constr2 @?= True


### PR DESCRIPTION
Old names are kept as pattern synonyms.