### PR TITLE
Produce more user-friendly error messages when the CBC solver exited with 0 but the output file was not generated

### DIFF
--- a/MIP/ChangeLog.md
+++ b/MIP/ChangeLog.md
@@ -8,6 +8,7 @@
 * Rename `S1` and `S2` to `SOS1` and `SOS2` respectively. Old names are kept as pattern synonyms.
 * Make `Tol` an instance of `Eq`, `Ord`, and `Show`
 * Add `Default` instance for `SOSConstraint`
+* Produce more user-friendly error messages when the CBC solver exited with 0 but the output file was not generated (thanks to @dpvanbalen)
 
 ## 0.2.0.0 (2025-02-03)
 

--- a/MIP/MIP.cabal
+++ b/MIP/MIP.cabal
@@ -175,6 +175,7 @@ library
     , case-insensitive >=1.2.0.11
     , containers >=0.5.0
     , data-default-class
+    , directory >=1.3.3.0 && <1.4.0.0
     , extended-reals >=0.1 && <1.0
     , filepath
     , hashable >=1.2.7.0 && <1.6.0.0

--- a/MIP/package.yaml
+++ b/MIP/package.yaml
@@ -91,6 +91,7 @@ library:
   - aeson >=1.4.2.0
   - bytestring >=0.10.8.2
   - case-insensitive >=1.2.0.11
+  - directory >=1.3.3.0 && <1.4.0.0
   - extended-reals >=0.1 && <1.0
   - filepath
   - hashable >=1.2.7.0 && <1.6.0.0

--- a/MIP/src/Numeric/Optimization/MIP/Solver/CBC.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/CBC.hs
@@ -17,10 +17,12 @@ module Numeric.Optimization.MIP.Solver.CBC
   , cbc
   ) where
 
+import Control.Monad
 import Data.Default.Class
 import qualified Data.Text.Lazy.IO as TLIO
+import System.Directory
 import System.Exit
-import System.IO
+import System.FilePath
 import System.IO.Temp
 import qualified Numeric.Optimization.MIP.Base as MIP
 import qualified Numeric.Optimization.MIP.LPFile as LPFile
@@ -49,35 +51,36 @@ instance IsSolver CBC IO where
     case LPFile.render def prob{ MIP.objectiveFunction = obj' } of
       Left err -> ioError $ userError err
       Right lp -> do
-        withSystemTempFile "cbc.lp" $ \fname1 h1 -> do
-          TLIO.hPutStr h1 lp
-          hClose h1
-          withSystemTempFile "cbc.sol" $ \fname2 h2 -> do
-            hClose h2
-            let args = cbcArgs solver
-                    ++ [fname1]
-                    ++ (case solveTimeLimit opt of
-                          Nothing -> []
-                          Just sec -> ["sec", show sec])
-                    ++ (case solveTol opt of
-                          Nothing -> []
-                          Just tol ->
-                            [ "integerTolerance", show (MIP.integralityTol tol)
-                            , "primalTolerance", show (MIP.feasibilityTol tol)
-                            , "dualTolerance", show (MIP.optimalityTol tol)
-                            ])
-                    ++ ["solve", "solu", fname2]
-                onGetLine = solveLogger opt
-                onGetErrorLine = solveErrorLogger opt
-            exitcode <- runProcessWithOutputCallback (cbcPath solver) args Nothing "" onGetLine onGetErrorLine
-            case exitcode of
-              ExitFailure n -> ioError $ userError $ "exit with " ++ show n
-              ExitSuccess -> do
-                sol <- CBCSol.readFile fname2
-                if isMax then
-                  return $ sol{ MIP.solObjectiveValue = fmap negate (MIP.solObjectiveValue sol) }
-                else
-                  return sol
+        withSystemTempDirectory "haskell-mip-cbc" $ \dir -> do
+          let fname1 = dir </> "cbc.lp"
+              fname2 = dir </> "cbc.sol"
+          TLIO.writeFile fname1 lp
+          let args = cbcArgs solver
+                  ++ [fname1]
+                  ++ (case solveTimeLimit opt of
+                        Nothing -> []
+                        Just sec -> ["sec", show sec])
+                  ++ (case solveTol opt of
+                        Nothing -> []
+                        Just tol ->
+                          [ "integerTolerance", show (MIP.integralityTol tol)
+                          , "primalTolerance", show (MIP.feasibilityTol tol)
+                          , "dualTolerance", show (MIP.optimalityTol tol)
+                          ])
+                  ++ ["solve", "solu", fname2]
+              onGetLine = solveLogger opt
+              onGetErrorLine = solveErrorLogger opt
+          exitcode <- runProcessWithOutputCallback (cbcPath solver) args Nothing "" onGetLine onGetErrorLine
+          case exitcode of
+            ExitFailure n -> ioError $ userError $ "exit with " ++ show n
+            ExitSuccess -> do
+              m <- doesFileExist fname2
+              unless m $ ioError $ userError "CBC returned exit code 0, but wrote no solution file. You may want to use the solveLogger or solveErrorLogger for more information"
+              sol <- CBCSol.readFile fname2
+              if isMax then
+                return $ sol{ MIP.solObjectiveValue = fmap negate (MIP.solObjectiveValue sol) }
+              else
+                return sol
     where
       obj = MIP.objectiveFunction prob
       isMax = MIP.objDir obj == MIP.OptMax

--- a/MIP/test/Test/MIPSolver.hs
+++ b/MIP/test/Test/MIPSolver.hs
@@ -1,10 +1,12 @@
 {-# OPTIONS_GHC -Wall -Wno-unused-top-binds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Test.MIPSolver (mipSolverTestGroup) where
 
 import Control.Arrow ((***))
+import Control.Exception
 import Control.Monad
 import Data.Default.Class
 import qualified Data.Map as Map
@@ -55,6 +57,20 @@ case_cbc_infeasible2 = do
       [ "expected: StatusInfeasible or StatusInfeasibleOrUnbounded"
       , " but got: " ++ show status
       ]
+
+case_cbc_no_output_file :: Assertion
+case_cbc_no_output_file = do
+  let prob = def
+       { MIP.constraints =
+           [ MIP.varExpr "x" - MIP.varExpr "x" MIP..<=. 0
+           ]
+       , MIP.varDomains = Map.fromList [("x", (MIP.ContinuousVariable, (0, 1)))]
+       }
+  ret <- try $ solve cbc def prob
+  let expected = userError "CBC returned exit code 0, but wrote no solution file. You may want to use the solveLogger or solveErrorLogger for more information"
+  case ret of
+    Left (e :: IOException) -> e @?= expected
+    Right _ -> assertFailure "An exception should have been raised"
 
 -- ------------------------------------------------------------------------
 
@@ -318,6 +334,7 @@ mipSolverTestGroup = testGroup "Test.MIPSolver" $ []
   , testCase "cbc unbounded" case_cbc_unbounded
   , testCase "cbc infeasible" case_cbc_infeasible
   , testCase "cbc infeasible2" case_cbc_infeasible2
+  , testCase "cbc no output file" case_cbc_no_output_file
   ]
 #endif
 #ifdef TEST_CPLEX


### PR DESCRIPTION
resolve #86
