### PR TITLE
GitHub Actions: fix an error during msys2 setup on the i386-windows environment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,7 +116,8 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           enable-stack: true
-          stack-version: 'latest'
+          # https://github.com/msakai/haskell-MIP/pull/93
+          stack-version: ${{ matrix.windows_32_or_64 == '32' && '3.5' || 'latest' }}
           stack-no-global: true
           stack-setup-ghc: true
 


### PR DESCRIPTION
E.g.

```
C:\Users\runneradmin\AppData\Local\Temp\stack-tmp-66be5605d5e80a37\msys32: renameDirectory:renamePath:MoveFileEx "\\\\?\\C:\\Users\\runneradmin\\AppData\\Local\\Temp\\stack-tmp-66be5605d5e80a37\\msys32" Just "\\\\?\\C:\\Users\\runneradmin\\AppData\\Local\\Programs\\stack\\i386-windows\\msys2-20200517": permission denied (Access is denied.)
```