### PR TITLE
Update PRINTEMPS default executable to printemps and require v2.8.0

### DIFF
--- a/MIP/ChangeLog.md
+++ b/MIP/ChangeLog.md
@@ -9,6 +9,7 @@
 * Make `Tol` an instance of `Eq`, `Ord`, and `Show`
 * Add `Default` instance for `SOSConstraint`
 * Produce more user-friendly error messages when the CBC solver exited with 0 but the output file was not generated (thanks to @dpvanbalen)
+* Change the default executable name for the printemps solver from `mps_solver` to `printemps`, and require PRINTEMPS version 2.8.0 or later (the standalone `mps_solver` executable has been deprecated)
 
 ## 0.2.0.0 (2025-02-03)
 

--- a/MIP/MIP.cabal
+++ b/MIP/MIP.cabal
@@ -120,7 +120,7 @@ flag TestLPSolve
   default: False
 
 flag TestPrintemps
-  description: run test cases that depend on mps_solver.exe command of printemps
+  description: run test cases that depend on printemps command of printemps
   manual: True
   default: False
 

--- a/MIP/package.yaml
+++ b/MIP/package.yaml
@@ -64,7 +64,7 @@ flags:
     default: False
 
   TestPrintemps:
-    description: run test cases that depend on mps_solver.exe command of printemps
+    description: run test cases that depend on printemps command of printemps
     manual: True
     default: False
 

--- a/MIP/src/Numeric/Optimization/MIP/Solver/Printemps.hs
+++ b/MIP/src/Numeric/Optimization/MIP/Solver/Printemps.hs
@@ -33,9 +33,9 @@ import Numeric.Optimization.MIP.Internal.ProcessUtil (runProcessWithOutputCallba
 import System.Exit
 import System.FilePath ((</>))
 
--- | A solver instance for calling @mps_solver.exe@ command from [PRINTEMPS](https://snowberryfield.github.io/printemps/).
+-- | A solver instance for calling @printemps@ command from [PRINTEMPS](https://snowberryfield.github.io/printemps/).
 --
--- It requires PRINTEMPS version 2.6.0 or later.
+-- It requires PRINTEMPS version 2.8.0 or later.
 --
 -- Use 'printemps' and record update syntax to modify its field.
 data Printemps
@@ -49,7 +49,7 @@ instance Default Printemps where
 
 -- | Default value of t'Printemps'
 printemps :: Printemps
-printemps = Printemps "mps_solver" []
+printemps = Printemps "printemps" []
 
 instance IsSolver Printemps IO where
   solve' solver opt prob = do


### PR DESCRIPTION
## Summary

PRINTEMPS [v2.8.0](https://github.com/snowberryfield/printemps/releases/tag/v2.8.0) deprecated the standalone `mps_solver` and `opb_solver` executables, integrating them into the unified `printemps` executable:

> The standalone solvers mps_solver and opb_solver are now deprecated. They have been fully integrated into the new executable printemps. Please migrate your workflows to printemps, as mps_solver and opb_solver will be removed in future releases.

This PR migrates the printemps solver driver accordingly.

## Changes

- **`MIP/src/Numeric/Optimization/MIP/Solver/Printemps.hs`**
  - Default executable: `mps_solver` → `printemps`
  - Required version bumped to 2.8.0 or later
  - Haddock reference `@mps_solver.exe@` → `@printemps@` (the `.exe` suffix was a leftover from an old era when the executable carried the extension regardless of OS)
- **`MIP/package.yaml`** / **`MIP/MIP.cabal`** — drop the stale `mps_solver.exe` mention in the `TestPrintemps` flag description
- **`MIP/ChangeLog.md`** — add an entry describing the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMj4G5KafQnuC5UdsoRzfS)_